### PR TITLE
Fix/google auth

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <!-- Google Signin library -->
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://apis.google.com/js/api.js"></script>
     <title>React App</title>
   </head>
   <body>

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import { UserContext } from './contexts/UserContext';
+
 const App = () => {
   // Passed to UserContext.Provider to set and share user data
   // with different components
@@ -12,6 +13,31 @@ const App = () => {
     imageUrl: null,
   });
   console.log('userData', userData);
+
+  const { gapi } = window;
+  useEffect(() => {
+    if (!userData.loggedIn) {
+      gapi.load('client:auth2', () => {
+        gapi.auth2
+          .init({
+            client_id: process.env.REACT_APP_CLIENT_ID,
+          })
+          .then((googleAuth) => {
+            if (googleAuth.isSignedIn.get()) {
+              const googleUser = googleAuth.currentUser.get();
+              const basicProfile = googleUser.getBasicProfile();
+              setUserData({
+                loggedIn: true,
+                name: basicProfile.getName(),
+                email: basicProfile.getEmail(),
+                imageUrl: basicProfile.getImageUrl(),
+              });
+            }
+          })
+          .catch((err) => console.error('error:', err));
+      });
+    }
+  }, [gapi, userData]);
 
   return (
     <div>

--- a/src/App.js
+++ b/src/App.js
@@ -17,14 +17,18 @@ const App = () => {
   const { gapi } = window;
   useEffect(() => {
     if (!userData.loggedIn) {
+      // loads auth2 client for Google JS Library
       gapi.load('client:auth2', () => {
+        // gapi.auth2.init() initializes and returns GoogleAuth object
         gapi.auth2
           .init({
             client_id: process.env.REACT_APP_CLIENT_ID,
           })
           .then((googleAuth) => {
+            // GoogleAuth.isSignedIn.get() returns a true if the user is signed in, or false if the user is signed out or the GoogleAuth object isn't initialized.
+            // sets user data if user signed in
             if (googleAuth.isSignedIn.get()) {
-              const googleUser = googleAuth.currentUser.get();
+              const googleUser = googleAuth.currentUser.get(); // Returns a GoogleUser object
               const basicProfile = googleUser.getBasicProfile();
               setUserData({
                 loggedIn: true,

--- a/src/components/shared/PrivateRoute.js
+++ b/src/components/shared/PrivateRoute.js
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { UserContext } from '../../contexts/UserContext';
+import { Route, Redirect } from 'react-router-dom';
+
+const PrivateRoute = ({ children, ...rest }) => {
+  const { userData } = useContext(UserContext);
+  return (
+    <Route
+      {...rest}
+      render={() => (userData.loggedIn ? children : <Redirect to='/' />)}
+    />
+  );
+};
+export default PrivateRoute;


### PR DESCRIPTION
Currently, when a page other than `LoginPage` refreshed or loaded `userData` returns `loggedIn: false` and user info as `null` even though user signed in before. To fix this added a new logic in App.js. It checks if a user is signed in and if it returns `true`, sets the user info to `userData`. 

Also added a `PrivateRoute` component to handle routing to pages that require sign in. It checks the `userData.loggedIn` and renders the child component if it returns `true`, else redirects to `LoginPage`.

closes #44 