### PR TITLE
Fix/header and layout

### DIFF
--- a/src/components/EventInfo.js
+++ b/src/components/EventInfo.js
@@ -20,16 +20,6 @@ export default function EventInfo(props) {
   return (
     <div className='mb-20 lg:mt-20 lg:mb-0'>
       <li className='list-none'>
-        {/* Link is temporary until menu/header merged */}
-        {/* It adds ability to go back to events page on mobile screens */}
-        <Link
-          to='/events'
-          onClick={() => props.setActiveEvent(false)}
-          className='inline-block lg:hidden'
-        >
-          {`< Back to events`}
-        </Link>
-
         <div className='flex flex-row justify-around'>
           <div id='left'>
             <p>Name:</p>

--- a/src/components/EventInfo.js
+++ b/src/components/EventInfo.js
@@ -5,7 +5,7 @@ import { EventsContext } from '../contexts/EventsContext';
 import { useParams, Link, useRouteMatch } from 'react-router-dom';
 import EventSubMenu from './EventSubMenu';
 
-export default function EventInfo(props) {
+export default function EventInfo() {
   const { eventId } = useParams();
   const { eventData } = useContext(EventsContext);
   const { url } = useRouteMatch();

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,8 +1,9 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { Icon } from '@iconify/react';
 import { UserContext } from '../contexts/UserContext';
 import SignoutButton from './shared/SignoutButton';
 import { Link } from 'react-router-dom';
+import { useRouteMatch, useLocation } from 'react-router-dom';
 
 const Header = (props) => {
   const { userData } = useContext(UserContext);
@@ -10,6 +11,25 @@ const Header = (props) => {
   const showUserInfoHandler = () => {
     setShowUserInfo((prev) => !prev);
   };
+  const { url, path } = useRouteMatch();
+  const location = useLocation();
+  console.log('location', location);
+  console.log('url', url);
+  console.log('path', path);
+
+  useEffect(() => setShowUserInfo(false), [location]);
+
+  useEffect(() => {
+    const listener = (event) => {
+      if (showUserInfo) {
+        setShowUserInfo(false);
+      }
+    };
+    document.addEventListener('click', listener);
+    return () => {
+      document.removeEventListener('click', listener);
+    };
+  }, [showUserInfo]);
 
   return (
     <header className='bg-white w-screen h-20 flex fixed justify-around items-center lg:hidden index z-50'>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,7 +12,7 @@ const Header = (props) => {
   };
 
   return (
-    <header className='bg-white w-screen h-20 flex fixed justify-around items-center lg:hidden'>
+    <header className='bg-white w-screen h-20 flex fixed justify-around items-center lg:hidden index z-50'>
       <Link
         to='/events'
         onClick={() => props.setActiveEvent(false)}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -11,7 +11,7 @@ const Header = (props) => {
   };
 
   return (
-    <header className='bg-white w-screen h-20 flex justify-around items-center lg:hidden'>
+    <header className='bg-white w-screen h-20 flex fixed justify-around items-center lg:hidden'>
       <Icon
         icon='ic:round-arrow-back-ios'
         color='#4a3f3f'

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,7 @@ import { useState, useContext } from 'react';
 import { Icon } from '@iconify/react';
 import { UserContext } from '../contexts/UserContext';
 import SignoutButton from './shared/SignoutButton';
+import { Link } from 'react-router-dom';
 
 const Header = (props) => {
   const { userData } = useContext(UserContext);
@@ -12,13 +13,20 @@ const Header = (props) => {
 
   return (
     <header className='bg-white w-screen h-20 flex fixed justify-around items-center lg:hidden'>
-      <Icon
-        icon='ic:round-arrow-back-ios'
-        color='#4a3f3f'
-        width='30'
-        height='30'
-        className={`${props.returnBtn ? '' : 'invisible'}`}
-      />
+      <Link
+        to='/events'
+        onClick={() => props.setActiveEvent(false)}
+        className='inline-block lg:hidden'
+      >
+        <Icon
+          icon='ic:round-arrow-back-ios'
+          color='#4a3f3f'
+          width='30'
+          height='30'
+          className={`${props.returnBtn ? '' : 'invisible'}`}
+        />
+      </Link>
+
       <h2 className='text-2xl'>{props.title}</h2>
       <img
         src={props.link}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,7 +3,6 @@ import { Icon } from '@iconify/react';
 import { UserContext } from '../contexts/UserContext';
 import SignoutButton from './shared/SignoutButton';
 import { Link } from 'react-router-dom';
-import { useRouteMatch, useLocation } from 'react-router-dom';
 
 const Header = (props) => {
   const { userData } = useContext(UserContext);
@@ -11,13 +10,6 @@ const Header = (props) => {
   const showUserInfoHandler = () => {
     setShowUserInfo((prev) => !prev);
   };
-  const { url, path } = useRouteMatch();
-  const location = useLocation();
-  console.log('location', location);
-  console.log('url', url);
-  console.log('path', path);
-
-  useEffect(() => setShowUserInfo(false), [location]);
 
   useEffect(() => {
     const listener = (event) => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -33,6 +33,7 @@ const Header = (props) => {
         alt='Profile Avatar'
         className='h-10 w-10 relative'
         onClick={showUserInfoHandler}
+        referrerPolicy='no-referrer'
       />
       {showUserInfo && (
         <div className='bg-gray-400 absolute top-16 right-1 w-60 shadow-md rounded p-2'>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -16,7 +16,9 @@ const Header = (props) => {
       <Link
         to='/events'
         onClick={() => props.setActiveEvent(false)}
-        className='inline-block lg:hidden'
+        className={`${
+          !props.activeEvent ? 'invisible' : 'inline-block'
+        } lg:hidden`}
       >
         <Icon
           icon='ic:round-arrow-back-ios'

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -83,6 +83,7 @@ const MenuBar = (props) => {
               src={userData.imageUrl}
               alt='Profile Avatar'
               className='h-12 w-12 m-2'
+              referrerPolicy='no-referrer'
             />
             <div>
               <div>{userData.name}</div>

--- a/src/components/ToDoList.js
+++ b/src/components/ToDoList.js
@@ -13,11 +13,6 @@ const ToDoList = (props) => {
 
   return (
     <React.Fragment>
-      {/* Link is temporary until menu/header merged
-      It adds ability to go back to event info page */}
-      <Link to={`/events/${eventId}`} className=''>
-        {`< Back to event info`}
-      </Link>
       <ul className='mt-20'>
         {todos.map((todo) => {
           return <ToDoItem key={todo.id} eventId={eventId} todo={todo} />;

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -19,7 +19,7 @@ export default function EventsPage() {
     <React.Fragment>
       <Header title='Breakfast' link={userData.imageUrl} returnBtn={true} />
       <MenuBar setActiveEvent={setActiveEvent} />
-      <div className='flex flex-row justify-around h-full lg:ml-56'>
+      <main className='flex flex-row justify-around h-full lg:ml-56'>
         {!activeEvent && <Redirect to='/events' />}
         <div
           className={`lg:w-1/3 flex justify-center overflow-y-auto ${
@@ -55,7 +55,7 @@ export default function EventsPage() {
             </Route>
           </Switch>
         </div>
-      </div>
+      </main>
     </React.Fragment>
   );
 }

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -16,6 +16,8 @@ export default function EventsPage() {
   const { path } = useRouteMatch();
   const [title, setTitle] = useState('');
 
+  console.log('activeEvent', activeEvent);
+
   function handleEventItemClick(eventName) {
     setActiveEvent(true);
     setTitle(eventName);

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -19,10 +19,10 @@ export default function EventsPage() {
     <React.Fragment>
       <Header title='Breakfast' link={userData.imageUrl} returnBtn={true} />
       <MenuBar setActiveEvent={setActiveEvent} />
-      <main className='flex flex-row justify-around h-full lg:ml-56'>
+      <main className='flex flex-row justify-around h-full lg:ml-56 overflow-y-scroll'>
         {!activeEvent && <Redirect to='/events' />}
         <div
-          className={`lg:w-1/3 flex justify-center overflow-y-auto ${
+          className={`lg:w-1/3 flex justify-center ${
             activeEvent && 'hidden lg:flex'
           }`}
         >
@@ -35,7 +35,7 @@ export default function EventsPage() {
           </ul>
         </div>
         <div
-          className={`w-screen lg:w-2/3 flex flex-col bg-gray-50 border-l overflow-y-auto px-8 sm:px-12 md:px-16 lg:px-20 xl:px-24 2xl:px-28 ${
+          className={`w-screen lg:w-2/3 flex flex-col bg-gray-50 border-l px-8 sm:px-12 md:px-16 lg:px-20 xl:px-24 2xl:px-28 ${
             !activeEvent && 'hidden lg:flex'
           }`}
         >

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -49,8 +49,7 @@ export default function EventsPage() {
               <NewEvent />
             </Route>
             <Route path={`/events/:eventId`} exact>
-              {/* setActiveEvent prop is temporary until menu/header merged */}
-              <EventInfo setActiveEvent={setActiveEvent} />
+              <EventInfo />
             </Route>
             <Route path='/events/:eventId/todos'>
               <ToDoList />

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -17,7 +17,12 @@ export default function EventsPage() {
 
   return (
     <React.Fragment>
-      <Header title='Breakfast' link={userData.imageUrl} returnBtn={true} />
+      <Header
+        title='Breakfast'
+        link={userData.imageUrl}
+        returnBtn={true}
+        setActiveEvent={setActiveEvent}
+      />
       <MenuBar setActiveEvent={setActiveEvent} />
       <main className='flex flex-row justify-around h-full lg:ml-56 overflow-y-scroll'>
         {!activeEvent && <Redirect to='/events' />}

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -14,11 +14,17 @@ export default function EventsPage() {
   const { eventData: events } = useContext(EventsContext);
   const { userData } = useContext(UserContext);
   const { path } = useRouteMatch();
+  const [title, setTitle] = useState('');
+
+  function handleEventItemClick(eventName) {
+    setActiveEvent(true);
+    setTitle(eventName);
+  }
 
   return (
     <React.Fragment>
       <Header
-        title='Breakfast'
+        title={activeEvent ? title : 'Events'}
         link={userData.imageUrl}
         returnBtn={true}
         setActiveEvent={setActiveEvent}
@@ -34,7 +40,10 @@ export default function EventsPage() {
           <ul className='flex flex-col space-y-10 items-center w-screen'>
             {events.map((event, index) => (
               <Link key={event.id} to={`/events/${event.id}`}>
-                <EventItem event={event} onClick={() => setActiveEvent(true)} />
+                <EventItem
+                  event={event}
+                  onClick={() => handleEventItemClick(event.name)}
+                />
               </Link>
             ))}
           </ul>

--- a/src/pages/EventsPage.js
+++ b/src/pages/EventsPage.js
@@ -28,6 +28,7 @@ export default function EventsPage() {
         link={userData.imageUrl}
         returnBtn={true}
         setActiveEvent={setActiveEvent}
+        activeEvent={activeEvent}
       />
       <MenuBar setActiveEvent={setActiveEvent} />
       <main className='flex flex-row justify-around h-[calc(100%-10rem)] lg:h-full lg:ml-40 xl:ml-56 relative top-20 lg:top-0'>

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -33,7 +33,7 @@ const LoginPage = () => {
   });
 
   return (
-    <div className='flex flex-col h-screen w-screen items-center justify-around'>
+    <main className='flex flex-col h-screen w-screen items-center justify-around'>
       <h1 className='text-6xl font-bold'>Meeting App?</h1>
       <img src={loginPagePic} alt='Meeting app' />
       <button
@@ -44,7 +44,7 @@ const LoginPage = () => {
         <span>Sign in with Google</span>
       </button>
       {error && <Alert error='Login failed!' detail={error} />}
-    </div>
+    </main>
   );
 };
 export default LoginPage;

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -30,7 +30,7 @@ const LoginPage = () => {
     <main className='flex flex-col justify-around items-center h-screen py-20'>
       <div className='flex flex-col items-center'>
         <h1 className='text-5xl lg:text-6xl font-bold text-center mb-8'>
-          Meeting App?
+          readyevent
         </h1>
         <img src={loginPagePic} alt='Meeting app' className='self-center' />
       </div>


### PR DESCRIPTION
What I did:
- Change outer divs on event page and login page to `<main>` for semantic reasons
- Fixed header to top of the page
- Remove "back to events" button and moved its feature to the headers back button
- Pass event name to header to display current selected events name in it

The main content (the event list) is now behind the header and menu bar, but it will be fixed by merging Emirs branch.
Also the back button on the main page (event page) needs to be removed 